### PR TITLE
fix(scanner): isolate camera capture pipeline

### DIFF
--- a/SWDestinyTrades/Classes/SwiftUI/Core/Scanner/CameraSession.swift
+++ b/SWDestinyTrades/Classes/SwiftUI/Core/Scanner/CameraSession.swift
@@ -8,51 +8,56 @@
 
 import AVFoundation
 
-/// Thin wrapper around `AVCaptureSession` that emits raw camera frames.
+/// Owns an `AVCaptureSession` and emits raw camera frames.
 ///
-/// Capture is configured and started on a private queue; frames are delivered on a separate
+/// Capture is configured and started on a private serial executor; frames are delivered on a separate
 /// sample queue so heavy work (Vision) never blocks the main thread. The session drops late
 /// frames, so processing one frame at a time is enough — no manual throttling required.
-final class CameraSession: NSObject {
+actor CameraSession {
 
-    let captureSession = AVCaptureSession()
+    private nonisolated let executor = DispatchSerialQueue(label: "com.swdestiny.camera.session")
 
-    private let sessionQueue = DispatchQueue(label: "com.swdestiny.camera.session")
+    nonisolated var unownedExecutor: UnownedSerialExecutor {
+        executor.asUnownedSerialExecutor()
+    }
+
+    /// AVFoundation requires the same session instance on its serial capture executor and in the
+    /// main-thread preview layer, but the SDK does not declare `AVCaptureSession` as `Sendable`.
+    /// No Swift mutable state is exposed through this reference; all session mutations stay here.
+    nonisolated(unsafe) let captureSession = AVCaptureSession()
+
     private let sampleQueue = DispatchQueue(label: "com.swdestiny.camera.samples")
     private let videoOutput = AVCaptureVideoDataOutput()
-
+    private let frameDelegate: CameraFrameDelegate
     private var isConfigured = false
-    private var frameHandler: ((CVPixelBuffer) -> Void)?
+
+    init(frameHandler: @escaping @Sendable (CVPixelBuffer) -> Void) {
+        frameDelegate = CameraFrameDelegate(frameHandler: frameHandler)
+    }
 
     // MARK: - Authorization
 
-    var authorizationStatus: AVAuthorizationStatus {
+    nonisolated var authorizationStatus: AVAuthorizationStatus {
         AVCaptureDevice.authorizationStatus(for: .video)
     }
 
-    func requestAccess() async -> Bool {
+    nonisolated func requestAccess() async -> Bool {
         await AVCaptureDevice.requestAccess(for: .video)
     }
 
     // MARK: - Lifecycle
 
-    /// Configures (once) and starts the session. `frameHandler` is called on a background queue.
-    func start(frameHandler: @escaping (CVPixelBuffer) -> Void) {
-        self.frameHandler = frameHandler
-        sessionQueue.async { [weak self] in
-            guard let self else { return }
-            configureIfNeeded()
-            if !captureSession.isRunning {
-                captureSession.startRunning()
-            }
+    /// Configures (once) and starts the session. Frames arrive on the background sample queue.
+    func start() {
+        configureIfNeeded()
+        if !captureSession.isRunning {
+            captureSession.startRunning()
         }
     }
 
     func stop() {
-        sessionQueue.async { [weak self] in
-            guard let self, captureSession.isRunning else { return }
-            captureSession.stopRunning()
-        }
+        guard captureSession.isRunning else { return }
+        captureSession.stopRunning()
     }
 
     // MARK: - Configuration
@@ -73,7 +78,7 @@ final class CameraSession: NSObject {
 
         videoOutput.alwaysDiscardsLateVideoFrames = true
         videoOutput.videoSettings = [kCVPixelBufferPixelFormatTypeKey as String: kCVPixelFormatType_32BGRA]
-        videoOutput.setSampleBufferDelegate(self, queue: sampleQueue)
+        videoOutput.setSampleBufferDelegate(frameDelegate, queue: sampleQueue)
 
         guard captureSession.canAddOutput(videoOutput) else {
             captureSession.commitConfiguration()
@@ -92,12 +97,19 @@ final class CameraSession: NSObject {
 
 // MARK: - AVCaptureVideoDataOutputSampleBufferDelegate
 
-extension CameraSession: AVCaptureVideoDataOutputSampleBufferDelegate {
+nonisolated private final class CameraFrameDelegate: NSObject, AVCaptureVideoDataOutputSampleBufferDelegate {
+
+    private let frameHandler: @Sendable (CVPixelBuffer) -> Void
+
+    init(frameHandler: @escaping @Sendable (CVPixelBuffer) -> Void) {
+        self.frameHandler = frameHandler
+        super.init()
+    }
 
     func captureOutput(_ output: AVCaptureOutput,
                        didOutput sampleBuffer: CMSampleBuffer,
                        from connection: AVCaptureConnection) {
         guard let pixelBuffer = CMSampleBufferGetImageBuffer(sampleBuffer) else { return }
-        frameHandler?(pixelBuffer)
+        frameHandler(pixelBuffer)
     }
 }

--- a/SWDestinyTrades/Classes/SwiftUI/Core/Scanner/EmbeddingCardMatcher.swift
+++ b/SWDestinyTrades/Classes/SwiftUI/Core/Scanner/EmbeddingCardMatcher.swift
@@ -12,7 +12,7 @@ import ImageIO
 /// Matches a card crop to the catalog by embedding it with the fine-tuned MobileCLIP encoder and
 /// finding the nearest scan embeddings. Tries all four orientations (cards get photographed sideways,
 /// and Battlefields are landscape), keeping the best score per card.
-final class EmbeddingCardMatcher: CardScanMatching {
+nonisolated final class EmbeddingCardMatcher: CardScanMatching {
 
     /// Score at/above which a match is pre-selected in the review sheet. Real-photo scores run
     /// ~0.55–0.85 for the right card; tune from the values shown in the UI.
@@ -26,20 +26,18 @@ final class EmbeddingCardMatcher: CardScanMatching {
 
     private let embedder: MobileCLIPEmbedder
     private let index: CardEmbeddingIndex
-    private let cardsByCode: [String: CardDTO]
 
-    init(embedder: MobileCLIPEmbedder, index: CardEmbeddingIndex, cards: [CardDTO]) {
+    init(embedder: MobileCLIPEmbedder, index: CardEmbeddingIndex) {
         self.embedder = embedder
         self.index = index
-        cardsByCode = Dictionary(cards.map { ($0.code, $0) }) { first, _ in first }
     }
 
-    func matches(_ image: CGImage, limit: Int) -> [ScannedCardResult] {
+    func matches(_ image: CGImage, limit: Int) -> [CardScanMatch] {
         let queries = Self.orientations.compactMap { try? embedder.embed(image, orientation: $0) }
         guard !queries.isEmpty else { return [] }
 
-        return index.nearest(toAny: queries, limit: limit).compactMap { hit in
-            cardsByCode[hit.code].map { ScannedCardResult(card: $0, confidence: hit.score) }
+        return index.nearest(toAny: queries, limit: limit).map { hit in
+            CardScanMatch(code: hit.code, confidence: hit.score)
         }
     }
 }

--- a/SWDestinyTrades/Classes/SwiftUI/Core/Scanner/MobileCLIPEmbedder.swift
+++ b/SWDestinyTrades/Classes/SwiftUI/Core/Scanner/MobileCLIPEmbedder.swift
@@ -8,23 +8,24 @@
 
 import CoreGraphics
 import CoreML
+import Synchronization
 import Vision
 
 /// Embeds a card crop with the bundled, fine-tuned MobileCLIP image encoder (Core ML, FP32).
 ///
 /// The encoder was fine-tuned so phone photos match the catalog scans (see Tooling/ml). The model
 /// bakes CLIP normalization; cosine normalization happens in `CardEmbeddingIndex`.
-final class MobileCLIPEmbedder {
+nonisolated final class MobileCLIPEmbedder: Sendable {
 
     static let bundledModelName = "MobileCLIPImage"
 
-    private let model: VNCoreMLModel
+    private let model: Mutex<VNCoreMLModel>
 
     init(modelURL: URL) throws {
         let configuration = MLModelConfiguration()
         configuration.computeUnits = .all
         let mlModel = try MLModel(contentsOf: modelURL, configuration: configuration)
-        model = try VNCoreMLModel(for: mlModel)
+        model = Mutex(try VNCoreMLModel(for: mlModel))
     }
 
     static func bundled(name: String = bundledModelName, in bundle: Bundle = .main) -> MobileCLIPEmbedder? {
@@ -40,16 +41,18 @@ final class MobileCLIPEmbedder {
 
     /// Embeds the image at the given orientation (used to try the 4 card rotations). CPU-bound.
     func embed(_ image: CGImage, orientation: CGImagePropertyOrientation) throws -> [Float] {
-        let request = VNCoreMLRequest(model: model)
-        request.imageCropAndScaleOption = .scaleFill
+        try model.withLock { model in
+            let request = VNCoreMLRequest(model: model)
+            request.imageCropAndScaleOption = .scaleFill
 
-        let handler = VNImageRequestHandler(cgImage: image, orientation: orientation, options: [:])
-        try handler.perform([request])
+            let handler = VNImageRequestHandler(cgImage: image, orientation: orientation, options: [:])
+            try handler.perform([request])
 
-        guard let observation = request.results?.first as? VNCoreMLFeatureValueObservation,
-              let multiArray = observation.featureValue.multiArrayValue else {
-            throw ScannerError.embeddingFailed
+            guard let observation = request.results?.first as? VNCoreMLFeatureValueObservation,
+                  let multiArray = observation.featureValue.multiArrayValue else {
+                throw ScannerError.embeddingFailed
+            }
+            return (0 ..< multiArray.count).map { multiArray[$0].floatValue }
         }
-        return (0 ..< multiArray.count).map { multiArray[$0].floatValue }
     }
 }

--- a/SWDestinyTrades/Classes/SwiftUI/Core/Scanner/ScanFramePipeline.swift
+++ b/SWDestinyTrades/Classes/SwiftUI/Core/Scanner/ScanFramePipeline.swift
@@ -8,7 +8,7 @@
 
 import CoreImage
 import CoreVideo
-import Foundation
+import Synchronization
 
 /// Crops the framed card and matches it on capture.
 ///
@@ -19,36 +19,41 @@ import Foundation
 ///
 /// Lives off the main actor: the camera delivers frames on its sample queue and calls `process`
 /// there, so cropping and Vision embedding never touch the main thread.
-final class ScanFramePipeline: @unchecked Sendable {
+/// Matcher replacement and capture requests cross executors, so that state lives in a compiler-
+/// checked `Mutex`; image processing remains synchronous on the serial sample queue.
+nonisolated final class ScanFramePipeline: Sendable {
 
-    struct Candidate {
+    private struct State {
+        var matcher: CardScanMatching?
+        var captureRequested = false
+    }
+
+    struct Candidate: Sendable {
         let crop: CGImage
-        let matches: [ScannedCardResult]
+        let matches: [CardScanMatch]
     }
 
     /// Standard trading-card aspect ratio (63mm × 88mm), width / height.
     static let cardAspect: CGFloat = 0.716
 
     private let ciContext = CIContext(options: nil)
-    private let lock = NSLock()
-    private var _matcher: CardScanMatching?
-    private var _captureRequested = false
+    private let state = Mutex(State())
 
     var matcher: CardScanMatching? {
-        get { lock.withLock { _matcher } }
-        set { lock.withLock { _matcher = newValue } }
+        get { state.withLock { $0.matcher } }
+        set { state.withLock { $0.matcher = newValue } }
     }
 
     func requestCapture() {
-        lock.withLock { _captureRequested = true }
+        state.withLock { $0.captureRequested = true }
     }
 
     /// Returns matched candidates only on the frame that fulfilled a capture request, else nil.
     func process(_ pixelBuffer: CVPixelBuffer) -> [Candidate]? {
-        let (currentMatcher, isCapture) = lock.withLock { () -> (CardScanMatching?, Bool) in
-            let capture = _captureRequested
-            _captureRequested = false
-            return (_matcher, capture)
+        let (currentMatcher, isCapture) = state.withLock { state -> (CardScanMatching?, Bool) in
+            let capture = state.captureRequested
+            state.captureRequested = false
+            return (state.matcher, capture)
         }
 
         guard isCapture, let crop = centerCardCrop(pixelBuffer) else {

--- a/SWDestinyTrades/Classes/SwiftUI/Core/Scanner/ScanMatching.swift
+++ b/SWDestinyTrades/Classes/SwiftUI/Core/Scanner/ScanMatching.swift
@@ -8,6 +8,12 @@
 
 import CoreGraphics
 
+/// Background-safe output from the image matcher. Catalog models are resolved on `MainActor`.
+nonisolated struct CardScanMatch: Equatable, Sendable {
+    let code: String
+    let confidence: Float
+}
+
 /// A resolved scan: the catalog card plus a 0...1 match score.
 struct ScannedCardResult: Equatable {
     let card: CardDTO
@@ -24,8 +30,8 @@ struct ScannedCardResult: Equatable {
     }
 }
 
-protocol CardScanMatching: AnyObject {
+nonisolated protocol CardScanMatching: AnyObject, Sendable {
     /// Returns the best catalog matches, best first. CPU-bound — call off the main thread.
     /// Implementations must be safe to call from a background queue (read-only after init).
-    func matches(_ image: CGImage, limit: Int) -> [ScannedCardResult]
+    func matches(_ image: CGImage, limit: Int) -> [CardScanMatch]
 }

--- a/SWDestinyTrades/Classes/SwiftUI/Features/Scanner/ViewModels/CardScannerViewModel.swift
+++ b/SWDestinyTrades/Classes/SwiftUI/Features/Scanner/ViewModels/CardScannerViewModel.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2026 Diogo Autilio. All rights reserved.
 //
 
+import AVFoundation
 import CoreGraphics
 import SwiftUI
 
@@ -39,9 +40,22 @@ final class CardScannerViewModel: BaseViewModel {
         reviewCandidates.filter(\.isSelected).count
     }
 
-    let cameraSession = CameraSession()
+    var previewSession: AVCaptureSession {
+        cameraSession.captureSession
+    }
+
     private let pipeline = ScanFramePipeline()
     private let injectedMatcher: CardScanMatching?
+    private var cardsByCode: [String: CardDTO] = [:]
+
+    @ObservationIgnored
+    lazy var cameraSession = CameraSession { [weak self, pipeline] pixelBuffer in
+        // Runs on the camera sample queue — cropping + matching stay off the main thread.
+        guard let candidates = pipeline.process(pixelBuffer) else { return }
+        Task { @MainActor in
+            self?.presentReview(for: candidates)
+        }
+    }
 
     private var service: SWDestinyServiceProtocol {
         dependencyContainer.resolve(type: SWDestinyServiceProtocol.self)
@@ -74,12 +88,15 @@ final class CardScannerViewModel: BaseViewModel {
         }
 
         guard cameraState == .authorized else { return }
-        startCamera()
+        await startCamera()
         await prepareMatcher()
     }
 
     func onDisappear() {
-        cameraSession.stop()
+        let cameraSession = cameraSession
+        Task {
+            await cameraSession.stop()
+        }
     }
 
     // MARK: - Actions
@@ -128,14 +145,8 @@ final class CardScannerViewModel: BaseViewModel {
 
     // MARK: - Camera pipeline
 
-    private func startCamera() {
-        cameraSession.start { [weak self, pipeline] pixelBuffer in
-            // Runs on the camera sample queue — cropping + matching stay off the main thread.
-            guard let candidates = pipeline.process(pixelBuffer) else { return }
-            Task { @MainActor in
-                self?.presentReview(for: candidates)
-            }
-        }
+    private func startCamera() async {
+        await cameraSession.start()
     }
 
     private func presentReview(for candidates: [ScanFramePipeline.Candidate]) {
@@ -144,13 +155,18 @@ final class CardScannerViewModel: BaseViewModel {
             return
         }
         reviewCandidates = candidates.map { candidate in
-            let best = candidate.matches.first?.confidence ?? 0
+            let matches = candidate.matches.compactMap { match in
+                cardsByCode[match.code].map { card in
+                    ScannedCardResult(card: card, confidence: match.confidence)
+                }
+            }
+            let best = matches.first?.confidence ?? 0
             // Too weak to be a real card → unrecognized (drives the "Not recognized" + manual-search UX).
             guard best >= EmbeddingCardMatcher.recognitionThreshold else {
                 return ScanCandidate(crop: candidate.crop, matches: [], chosenIndex: 0, isSelected: false)
             }
             let confident = best >= EmbeddingCardMatcher.defaultThreshold
-            return ScanCandidate(crop: candidate.crop, matches: candidate.matches, chosenIndex: 0, isSelected: confident)
+            return ScanCandidate(crop: candidate.crop, matches: matches, chosenIndex: 0, isSelected: confident)
         }
         isReviewPresented = true
     }
@@ -160,16 +176,18 @@ final class CardScannerViewModel: BaseViewModel {
     private func prepareMatcher() async {
         guard pipeline.matcher == nil else { return }
 
+        // Feedback while the catalog loads, otherwise the screen looks idle (button disabled).
+        indexState = .building(0)
+
+        let cards = await (try? service.retrieveAllCards()) ?? []
+        cardsByCode = Dictionary(cards.map { ($0.code, $0) }) { first, _ in first }
+
         if let injectedMatcher {
             pipeline.matcher = injectedMatcher
             indexState = .ready
             return
         }
 
-        // Feedback while the catalog loads, otherwise the screen looks idle (button disabled).
-        indexState = .building(0)
-
-        let cards = await (try? service.retrieveAllCards()) ?? []
         guard !cards.isEmpty,
               let embedder = MobileCLIPEmbedder.bundled(),
               let url = Bundle.main.url(forResource: "card-embeddings", withExtension: "swdx"),
@@ -180,7 +198,7 @@ final class CardScannerViewModel: BaseViewModel {
         }
 
         let index = CardEmbeddingIndex(entries: entries)
-        pipeline.matcher = EmbeddingCardMatcher(embedder: embedder, index: index, cards: cards)
+        pipeline.matcher = EmbeddingCardMatcher(embedder: embedder, index: index)
         indexState = .ready
     }
 }

--- a/SWDestinyTrades/Classes/SwiftUI/Features/Scanner/ViewModels/CardScannerViewModel.swift
+++ b/SWDestinyTrades/Classes/SwiftUI/Features/Scanner/ViewModels/CardScannerViewModel.swift
@@ -182,14 +182,19 @@ final class CardScannerViewModel: BaseViewModel {
         let cards = await (try? service.retrieveAllCards()) ?? []
         cardsByCode = Dictionary(cards.map { ($0.code, $0) }) { first, _ in first }
 
+        // Without the catalog no match can be resolved to a card, even with a working matcher.
+        guard !cards.isEmpty else {
+            indexState = .failed
+            return
+        }
+
         if let injectedMatcher {
             pipeline.matcher = injectedMatcher
             indexState = .ready
             return
         }
 
-        guard !cards.isEmpty,
-              let embedder = MobileCLIPEmbedder.bundled(),
+        guard let embedder = MobileCLIPEmbedder.bundled(),
               let url = Bundle.main.url(forResource: "card-embeddings", withExtension: "swdx"),
               let entries = try? CardEmbeddingIndex.load(from: url),
               !entries.isEmpty else {

--- a/SWDestinyTrades/Classes/SwiftUI/Features/Scanner/Views/CardScannerView.swift
+++ b/SWDestinyTrades/Classes/SwiftUI/Features/Scanner/Views/CardScannerView.swift
@@ -45,7 +45,7 @@ struct CardScannerView: View {
         ZStack {
             Color.black
 
-            CameraPreviewView(session: viewModel.cameraSession.captureSession)
+            CameraPreviewView(session: viewModel.previewSession)
 
             RoundedRectangle(cornerRadius: 12)
                 .stroke(.white.opacity(0.9), lineWidth: 3)


### PR DESCRIPTION
This pull request refactors the card scanning pipeline to improve thread safety, background execution, and separation of responsibilities. The main changes involve making the image processing pipeline, matcher, and embedder explicitly `Sendable` and thread-safe, introducing a new background-safe `CardScanMatch` type, and updating the camera session to use Swift concurrency features. The view model is updated to assemble results from background threads and resolve catalog models on the main thread.

**Concurrency and Thread Safety Improvements**
- Refactored `ScanFramePipeline`, `EmbeddingCardMatcher`, and `MobileCLIPEmbedder` to be `nonisolated` and `Sendable`, using the new `Mutex` type for state and model access to ensure thread safety when accessed from background queues. (`SWDestinyTrades/Classes/SwiftUI/Core/Scanner/ScanFramePipeline.swift` [[1]](diffhunk://#diff-b8791323d482320aeb09f180f29bb60a4f0eb12c9fa9bc91272c9075e4063875L22-R56) [[2]](diffhunk://#diff-b8791323d482320aeb09f180f29bb60a4f0eb12c9fa9bc91272c9075e4063875L11-R11); `SWDestinyTrades/Classes/SwiftUI/Core/Scanner/EmbeddingCardMatcher.swift` [[3]](diffhunk://#diff-1135f78b060becef9a3c7ab16465ebf23765d90982ec49bc765f4fdd315e2ca7L15-R15) [[4]](diffhunk://#diff-1135f78b060becef9a3c7ab16465ebf23765d90982ec49bc765f4fdd315e2ca7L29-R40); `SWDestinyTrades/Classes/SwiftUI/Core/Scanner/MobileCLIPEmbedder.swift` [[5]](diffhunk://#diff-11f57a67e89aa1d05e050be011a5500959e959e79251c647e7528daa74d6ef41R11-R28) [[6]](diffhunk://#diff-11f57a67e89aa1d05e050be011a5500959e959e79251c647e7528daa74d6ef41R44) [[7]](diffhunk://#diff-11f57a67e89aa1d05e050be011a5500959e959e79251c647e7528daa74d6ef41R58)
- Introduced a new `CardScanMatch` struct and updated the `CardScanMatching` protocol to return background-safe matches, separating raw scan results from catalog lookups (which are now performed on the main thread). (`SWDestinyTrades/Classes/SwiftUI/Core/Scanner/ScanMatching.swift` [[1]](diffhunk://#diff-53b1d034ef9e8eca86863df0e111fd38d97a8ec85bcc234241866022635c37a9R11-R16) [[2]](diffhunk://#diff-53b1d034ef9e8eca86863df0e111fd38d97a8ec85bcc234241866022635c37a9L27-R36)

**Camera Session Modernization**
- Refactored `CameraSession` to be an `actor`, using a serial executor for AVFoundation session access, and moved frame delivery to a dedicated delegate class. The session is now started and stopped using async/await. (`SWDestinyTrades/Classes/SwiftUI/Core/Scanner/CameraSession.swift` [[1]](diffhunk://#diff-23b45368879ac46660c252754aeac833ae2564e6c0b2cb817ae6cae8db8e37c4L11-L56) [[2]](diffhunk://#diff-23b45368879ac46660c252754aeac833ae2564e6c0b2cb817ae6cae8db8e37c4L76-R81) [[3]](diffhunk://#diff-23b45368879ac46660c252754aeac833ae2564e6c0b2cb817ae6cae8db8e37c4L95-R113)

**View Model and UI Integration**
- Updated `CardScannerViewModel` to assemble `ScannedCardResult` objects on the main thread from background `CardScanMatch` results, and to manage the catalog lookup and matcher lifecycle in a thread-safe manner. (`SWDestinyTrades/Classes/SwiftUI/Features/Scanner/ViewModels/CardScannerViewModel.swift` [[1]](diffhunk://#diff-7eb3c2a98316daaa40a91ab2eac66e0d0227a53abeb02c6e434a3f78369c75feL42-R58) [[2]](diffhunk://#diff-7eb3c2a98316daaa40a91ab2eac66e0d0227a53abeb02c6e434a3f78369c75feL77-R99) [[3]](diffhunk://#diff-7eb3c2a98316daaa40a91ab2eac66e0d0227a53abeb02c6e434a3f78369c75feL131-R149) [[4]](diffhunk://#diff-7eb3c2a98316daaa40a91ab2eac66e0d0227a53abeb02c6e434a3f78369c75feL147-R169) [[5]](diffhunk://#diff-7eb3c2a98316daaa40a91ab2eac66e0d0227a53abeb02c6e434a3f78369c75feR179-L172) [[6]](diffhunk://#diff-7eb3c2a98316daaa40a91ab2eac66e0d0227a53abeb02c6e434a3f78369c75feL183-R201)
- Minor update to `CardScannerView` to use the new preview session accessor. (`SWDestinyTrades/Classes/SwiftUI/Features/Scanner/Views/CardScannerView.swift` [SWDestinyTrades/Classes/SwiftUI/Features/Scanner/Views/CardScannerView.swiftL48-R48](diffhunk://#diff-9a283f3dd8c734f95079a31d0ae0b50cf365001697eb354bcb5ab9bf89281909L48-R48))

These changes make the scanning pipeline safer and more robust for concurrent execution, and clarify the separation between background image processing and main-thread UI/catalog logic.