### PR TITLE
Fix redundant URL requirement and SwiftData observation warning

### DIFF
--- a/SWDestinyTrades/Classes/Database/SwiftDataManager.swift
+++ b/SWDestinyTrades/Classes/Database/SwiftDataManager.swift
@@ -263,7 +263,7 @@ private final class SwiftDataObservation<T: Storable>: DatabaseObservation {
             object: database,
             queue: .main
         ) { [weak self] _ in
-            Task { @MainActor [weak self] in
+            MainActor.assumeIsolated {
                 self?.fetchCurrentValue()
             }
         }

--- a/SWDestinyTradesTests/Rest/SWDestinyServiceTests.swift
+++ b/SWDestinyTradesTests/Rest/SWDestinyServiceTests.swift
@@ -53,8 +53,8 @@ final class SWDestinyServiceTests: BaseTestCase {
     }
 
     @Test
-    func testCancelRequest() throws {
-        let request = try URLRequest(with: #require(URL(string: "https://base.url.com")))
+    func testCancelRequest() {
+        let request = URLRequest(with: URL(string: "https://base.url.com"))
         sut.cancelRequest(request)
 
         #expect(mockHttpClient.isCancelled)


### PR DESCRIPTION
This pull request makes small improvements to both the database observation logic and the unit tests. The changes focus on simplifying code and improving test reliability.

Code simplification:

* [`SWDestinyTrades/Classes/Database/SwiftDataManager.swift`](diffhunk://#diff-4c425860d38295180f46b8b3f99da8feb78b0301e938e811d6f42b199c03e68fL266-R266): Replaces the use of a `Task` with `MainActor.assumeIsolated` in the database observation callback, ensuring that `fetchCurrentValue()` is called on the main actor in a more direct and efficient way.

Test reliability and clarity:

* [`SWDestinyTradesTests/Rest/SWDestinyServiceTests.swift`](diffhunk://#diff-9c4a2427959a3c82fe7a2477e339e3ac8608783b7d2a2b954951290c216d6d08L56-R57): Removes unnecessary error handling and the `#require` macro in `testCancelRequest`, simplifying the test setup and making the test easier to read and maintain.